### PR TITLE
fix: [PhU-354] registration field validation

### DIFF
--- a/src/register/data/utils.js
+++ b/src/register/data/utils.js
@@ -73,11 +73,6 @@ export const isFormValid = (
     }
   });
 
-  if (getConfig().SHOW_CONFIGURABLE_EDX_FIELDS) {
-    if (!configurableFormFields?.country?.displayValue) {
-      isValid = true;
-    }
-  }
   Object.keys(fieldDescriptions).forEach(key => {
     if (key === 'country' && !configurableFormFields.country.displayValue) {
       fieldErrors[key] = formatMessage(messages['empty.country.field.error']);


### PR DESCRIPTION
### Description
This validation block is to blame for everything:

```
  if (getConfig().SHOW_CONFIGURABLE_EDX_FIELDS) {
    if (!configurableFormFields?.country?.displayValue) {
      isValid = true;
    }
  }
```

The problem is that this block neutralizes the validation that occurred before it.

When this block is removed, everything works correctly as on Quince Dev:
<img width="675" alt="Знімок екрана 2024-06-17 о 17 29 01" src="https://github.com/GSVlabs/frontend-app-authn/assets/98233552/4f87cb61-bd91-43fe-981f-3676f8c32cfb">

### YouTrack:
- https://youtrack.raccoongang.com/issue/PhU-354
