### PR TITLE
fix: [PhU-390] saving organization during registration

### DIFF
--- a/src/progressive-profiling/OrganizationFormField.jsx
+++ b/src/progressive-profiling/OrganizationFormField.jsx
@@ -21,7 +21,7 @@ const OrganizationFormField = (props) => {
   const {
     valueOrgField,
     onChangeHandler,
-    setOrgId,
+    onSetOrgId,
     onShowCustomFormFields,
     onSelecteOrganizationHandler,
     setOptions,
@@ -106,7 +106,7 @@ const OrganizationFormField = (props) => {
 
   const handleInputChange = (newValue, actionMeta) => {
     if (actionMeta.action === 'input-change') {
-      setOrgId(null);
+      onSetOrgId(null);
       onChangeHandler({ target: { name: 'organization', value: newValue.trim() } });
     }
   };
@@ -159,7 +159,7 @@ OrganizationFormField.propTypes = {
   optionsMenuOpen: PropTypes.bool,
   setOptionsMenuOpen: PropTypes.func,
   onChangeHandler: PropTypes.func,
-  setOrgId: PropTypes.func,
+  onSetOrgId: PropTypes.func,
   setOptions: PropTypes.func,
   onShowCustomFormFields: PropTypes.func,
   onSelecteOrganizationHandler: PropTypes.func,
@@ -172,7 +172,7 @@ OrganizationFormField.defaultProps = {
   optionsMenuOpen: {},
   setOptionsMenuOpen: () => {},
   onChangeHandler: () => {},
-  setOrgId: () => {},
+  onSetOrgId: () => {},
   setOptions: () => {},
   onShowCustomFormFields: () => {},
   onSelecteOrganizationHandler: () => {},

--- a/src/progressive-profiling/ProgressiveProfiling.jsx
+++ b/src/progressive-profiling/ProgressiveProfiling.jsx
@@ -210,7 +210,12 @@ const ProgressiveProfiling = (props) => {
 
   const onChangeHandler = (event) => {
     if (event) {
-      setValues({ ...values, [event.target.name]: event.target.value });
+      if (event.target.name === 'organization') {
+        // In order to clear the state of additional fields when the organization name changes
+        setValues({ [event.target.name]: event.target.value });
+      } else {
+        setValues({ ...values, [event.target.name]: event.target.value });
+      }
     } else {
       setValues({});
     }
@@ -220,6 +225,7 @@ const ProgressiveProfiling = (props) => {
     if (!selectedOption) {
       onChangeHandler({ target: { name: 'organization', value: null } });
       setValues({});
+      setOrgId(null);
       setShowCustomFormFields(false);
       return;
     }


### PR DESCRIPTION
### Description

- Fixed cleaning of `OrgId` after the organization is selected from the existing ones in the database and then a new name of the organization is written in the Organization name field.
- Added clearing of the state of additional fields when changing the organization name.

### YouTrack

https://youtrack.raccoongang.com/issue/PhU-390
